### PR TITLE
Phase 3 hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ predicate-authorityd \
 
 `predicate-authority` provides an ops-focused CLI for sidecar/runtime workflows.
 
+### Ops docs quick links
+
+- Sidecar operations guide: `docs/authorityd-operations.md`
+- User manual (sync/integrity/operator behaviors): `docs/predicate-authority-user-manual.md`
+- Control-plane production hardening runbook: `../predicate-authority-control-plane/docs/production-hardening-runbook.md`
+
 ### Sidecar health and status
 
 ```bash

--- a/docs/authorityd-operations.md
+++ b/docs/authorityd-operations.md
@@ -63,6 +63,40 @@ PYTHONPATH=. predicate-authorityd \
   --control-plane-fail-open
 ```
 
+### Optional: enable long-poll policy/revocation sync from control-plane
+
+Use this when running `cloud_connected` mode and you want active policy/revocation
+updates pushed through long-poll sync instead of waiting for file-based policy polling.
+
+```bash
+export CONTROL_PLANE_URL="http://127.0.0.1:8080"
+export CONTROL_PLANE_TENANT_ID="dev-tenant"
+export CONTROL_PLANE_PROJECT_ID="dev-project"
+export CONTROL_PLANE_AUTH_TOKEN="<bearer-token>"
+
+PYTHONPATH=. predicate-authorityd \
+  --host 127.0.0.1 \
+  --port 8787 \
+  --mode cloud_connected \
+  --policy-file examples/authorityd/policy.json \
+  --control-plane-enabled \
+  --control-plane-sync-enabled \
+  --control-plane-sync-project-id "$CONTROL_PLANE_PROJECT_ID" \
+  --control-plane-sync-environment "prod" \
+  --control-plane-sync-wait-timeout-s 15 \
+  --control-plane-sync-poll-interval-ms 200
+```
+
+Quick checks:
+
+```bash
+# daemon sync health counters
+curl -s http://127.0.0.1:8787/status | jq '.control_plane_sync_poll_count, .control_plane_sync_update_count, .control_plane_sync_error_count, .control_plane_last_sync_error'
+
+# daemon metrics includes control-plane sync counters
+curl -s http://127.0.0.1:8787/metrics | rg "predicate_authority_control_plane_sync_total"
+```
+
 ### Signing key safety note (required until mandate `v2` claims)
 
 Until mandate `v2` introduces explicit `iss`/`aud` claims and asymmetric signing defaults,

--- a/predicate_authority/metrics.py
+++ b/predicate_authority/metrics.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DaemonMetricsSnapshot:
+    daemon_up: int
+    policy_reload_total: int
+    policy_poll_error_total: int
+    proof_event_total: int
+    authz_decision_total: int
+    authz_allow_total: int
+    authz_deny_total: int
+    authz_deny_no_matching_policy_total: int
+    authz_deny_explicit_deny_total: int
+    authz_deny_missing_required_verification_total: int
+    authz_deny_max_delegation_depth_total: int
+    authz_deny_invalid_mandate_total: int
+    authz_deny_rate_limit_exceeded_total: int
+    revoked_principal_total: int
+    revoked_intent_total: int
+    revoked_mandate_total: int
+    flush_cycle_total: int
+    flush_sent_total: int
+    flush_failed_total: int
+    flush_quarantined_total: int
+    control_plane_sync_poll_total: int
+    control_plane_sync_update_total: int
+    control_plane_sync_error_total: int
+    local_flush_queue_pending: int
+    local_flush_queue_flushed: int
+    local_flush_queue_failed: int
+    local_flush_queue_quarantined: int
+    control_plane_audit_push_success_total: int
+    control_plane_audit_push_failure_total: int
+    control_plane_usage_push_success_total: int
+    control_plane_usage_push_failure_total: int
+
+    @classmethod
+    def from_status_payload(cls, payload: dict[str, object]) -> DaemonMetricsSnapshot:
+        def _to_int(key: str) -> int:
+            value = payload.get(key, 0)
+            if isinstance(value, bool):
+                return int(value)
+            if isinstance(value, int):
+                return value
+            if isinstance(value, float):
+                return int(value)
+            if isinstance(value, str) and value.strip() != "":
+                return int(float(value))
+            return 0
+
+        return cls(
+            daemon_up=_to_int("daemon_running"),
+            policy_reload_total=_to_int("policy_reload_count"),
+            policy_poll_error_total=_to_int("policy_poll_error_count"),
+            proof_event_total=_to_int("proof_event_count"),
+            authz_decision_total=_to_int("authorization_decision_total"),
+            authz_allow_total=_to_int("authorization_allow_total"),
+            authz_deny_total=_to_int("authorization_deny_total"),
+            authz_deny_no_matching_policy_total=_to_int(
+                "authorization_deny_no_matching_policy_total"
+            ),
+            authz_deny_explicit_deny_total=_to_int("authorization_deny_explicit_deny_total"),
+            authz_deny_missing_required_verification_total=_to_int(
+                "authorization_deny_missing_required_verification_total"
+            ),
+            authz_deny_max_delegation_depth_total=_to_int(
+                "authorization_deny_max_delegation_depth_total"
+            ),
+            authz_deny_invalid_mandate_total=_to_int("authorization_deny_invalid_mandate_total"),
+            authz_deny_rate_limit_exceeded_total=_to_int(
+                "authorization_deny_rate_limit_exceeded_total"
+            ),
+            revoked_principal_total=_to_int("revoked_principal_count"),
+            revoked_intent_total=_to_int("revoked_intent_count"),
+            revoked_mandate_total=_to_int("revoked_mandate_count"),
+            flush_cycle_total=_to_int("flush_cycle_count"),
+            flush_sent_total=_to_int("flush_sent_count"),
+            flush_failed_total=_to_int("flush_failed_count"),
+            flush_quarantined_total=_to_int("flush_quarantined_count"),
+            control_plane_sync_poll_total=_to_int("control_plane_sync_poll_count"),
+            control_plane_sync_update_total=_to_int("control_plane_sync_update_count"),
+            control_plane_sync_error_total=_to_int("control_plane_sync_error_count"),
+            local_flush_queue_pending=_to_int("local_flush_queue_pending_count"),
+            local_flush_queue_flushed=_to_int("local_flush_queue_flushed_count"),
+            local_flush_queue_failed=_to_int("local_flush_queue_failed_count"),
+            local_flush_queue_quarantined=_to_int("local_flush_queue_quarantined_count"),
+            control_plane_audit_push_success_total=_to_int(
+                "control_plane_audit_push_success_count"
+            ),
+            control_plane_audit_push_failure_total=_to_int(
+                "control_plane_audit_push_failure_count"
+            ),
+            control_plane_usage_push_success_total=_to_int(
+                "control_plane_usage_push_success_count"
+            ),
+            control_plane_usage_push_failure_total=_to_int(
+                "control_plane_usage_push_failure_count"
+            ),
+        )
+
+
+def render_daemon_prometheus_metrics(payload: dict[str, object]) -> str:
+    snapshot = DaemonMetricsSnapshot.from_status_payload(payload)
+    lines = [
+        "# HELP predicate_authority_daemon_up Daemon process liveness (1=running,0=stopped).",
+        "# TYPE predicate_authority_daemon_up gauge",
+        f"predicate_authority_daemon_up {snapshot.daemon_up}",
+        "# HELP predicate_authority_policy_reload_total Policy reload count.",
+        "# TYPE predicate_authority_policy_reload_total counter",
+        f"predicate_authority_policy_reload_total {snapshot.policy_reload_total}",
+        "# HELP predicate_authority_policy_poll_error_total Policy poll error count.",
+        "# TYPE predicate_authority_policy_poll_error_total counter",
+        f"predicate_authority_policy_poll_error_total {snapshot.policy_poll_error_total}",
+        "# HELP predicate_authority_proof_event_total Recorded proof events.",
+        "# TYPE predicate_authority_proof_event_total counter",
+        f"predicate_authority_proof_event_total {snapshot.proof_event_total}",
+        "# HELP predicate_authority_authz_decision_total Authorization decision totals by outcome.",
+        "# TYPE predicate_authority_authz_decision_total counter",
+        f'predicate_authority_authz_decision_total{{outcome="allow"}} {snapshot.authz_allow_total}',
+        f'predicate_authority_authz_decision_total{{outcome="deny"}} {snapshot.authz_deny_total}',
+        "# HELP predicate_authority_authz_deny_reason_total Authorization deny totals by reason.",
+        "# TYPE predicate_authority_authz_deny_reason_total counter",
+        (
+            'predicate_authority_authz_deny_reason_total{reason="no_matching_policy"} '
+            f"{snapshot.authz_deny_no_matching_policy_total}"
+        ),
+        (
+            'predicate_authority_authz_deny_reason_total{reason="explicit_deny"} '
+            f"{snapshot.authz_deny_explicit_deny_total}"
+        ),
+        (
+            'predicate_authority_authz_deny_reason_total{reason="missing_required_verification"} '
+            f"{snapshot.authz_deny_missing_required_verification_total}"
+        ),
+        (
+            'predicate_authority_authz_deny_reason_total{reason="max_delegation_depth_exceeded"} '
+            f"{snapshot.authz_deny_max_delegation_depth_total}"
+        ),
+        (
+            'predicate_authority_authz_deny_reason_total{reason="invalid_mandate"} '
+            f"{snapshot.authz_deny_invalid_mandate_total}"
+        ),
+        (
+            'predicate_authority_authz_deny_reason_total{reason="rate_limit_exceeded"} '
+            f"{snapshot.authz_deny_rate_limit_exceeded_total}"
+        ),
+        "# HELP predicate_authority_revocation_total Revocations by type.",
+        "# TYPE predicate_authority_revocation_total gauge",
+        (
+            'predicate_authority_revocation_total{type="principal"} '
+            f"{snapshot.revoked_principal_total}"
+        ),
+        f'predicate_authority_revocation_total{{type="intent"}} {snapshot.revoked_intent_total}',
+        f'predicate_authority_revocation_total{{type="mandate"}} {snapshot.revoked_mandate_total}',
+        "# HELP predicate_authority_flush_total Flush loop counters by result.",
+        "# TYPE predicate_authority_flush_total counter",
+        f'predicate_authority_flush_total{{result="cycle"}} {snapshot.flush_cycle_total}',
+        f'predicate_authority_flush_total{{result="sent"}} {snapshot.flush_sent_total}',
+        f'predicate_authority_flush_total{{result="failed"}} {snapshot.flush_failed_total}',
+        (
+            'predicate_authority_flush_total{result="quarantined"} '
+            f"{snapshot.flush_quarantined_total}"
+        ),
+        "# HELP predicate_authority_control_plane_sync_total Control-plane sync loop counters by result.",
+        "# TYPE predicate_authority_control_plane_sync_total counter",
+        (
+            'predicate_authority_control_plane_sync_total{result="poll"} '
+            f"{snapshot.control_plane_sync_poll_total}"
+        ),
+        (
+            'predicate_authority_control_plane_sync_total{result="update"} '
+            f"{snapshot.control_plane_sync_update_total}"
+        ),
+        (
+            'predicate_authority_control_plane_sync_total{result="error"} '
+            f"{snapshot.control_plane_sync_error_total}"
+        ),
+        "# HELP predicate_authority_local_flush_queue Queue depth and lifecycle gauges.",
+        "# TYPE predicate_authority_local_flush_queue gauge",
+        (
+            'predicate_authority_local_flush_queue{state="pending"} '
+            f"{snapshot.local_flush_queue_pending}"
+        ),
+        (
+            'predicate_authority_local_flush_queue{state="flushed"} '
+            f"{snapshot.local_flush_queue_flushed}"
+        ),
+        (
+            'predicate_authority_local_flush_queue{state="failed"} '
+            f"{snapshot.local_flush_queue_failed}"
+        ),
+        (
+            'predicate_authority_local_flush_queue{state="quarantined"} '
+            f"{snapshot.local_flush_queue_quarantined}"
+        ),
+        "# HELP predicate_authority_control_plane_push_total Control-plane push attempts by stream/result.",
+        "# TYPE predicate_authority_control_plane_push_total counter",
+        (
+            'predicate_authority_control_plane_push_total{stream="audit",result="success"} '
+            f"{snapshot.control_plane_audit_push_success_total}"
+        ),
+        (
+            'predicate_authority_control_plane_push_total{stream="audit",result="failure"} '
+            f"{snapshot.control_plane_audit_push_failure_total}"
+        ),
+        (
+            'predicate_authority_control_plane_push_total{stream="usage",result="success"} '
+            f"{snapshot.control_plane_usage_push_success_total}"
+        ),
+        (
+            'predicate_authority_control_plane_push_total{stream="usage",result="failure"} '
+            f"{snapshot.control_plane_usage_push_failure_total}"
+        ),
+    ]
+    return "\n".join(lines) + "\n"

--- a/predicate_authority/proof.py
+++ b/predicate_authority/proof.py
@@ -4,7 +4,26 @@ import time
 from dataclasses import dataclass, field
 from threading import Lock
 
-from predicate_contracts import ActionRequest, AuthorizationDecision, ProofEvent, TraceEmitter
+from predicate_contracts import (
+    ActionRequest,
+    AuthorizationDecision,
+    AuthorizationReason,
+    ProofEvent,
+    TraceEmitter,
+)
+
+
+@dataclass(frozen=True)
+class DecisionStats:
+    total: int
+    allowed: int
+    denied: int
+    deny_no_matching_policy: int
+    deny_explicit_deny: int
+    deny_missing_required_verification: int
+    deny_max_delegation_depth: int
+    deny_invalid_mandate: int
+    deny_rate_limit_exceeded: int
 
 
 @dataclass
@@ -34,3 +53,43 @@ class InMemoryProofLedger:
     def event_count(self) -> int:
         with self._lock:
             return len(self.events)
+
+    def decision_stats(self) -> DecisionStats:
+        with self._lock:
+            events = tuple(self.events)
+        allowed = 0
+        denied = 0
+        deny_no_matching_policy = 0
+        deny_explicit_deny = 0
+        deny_missing_required_verification = 0
+        deny_max_delegation_depth = 0
+        deny_invalid_mandate = 0
+        deny_rate_limit_exceeded = 0
+        for event in events:
+            if event.allowed:
+                allowed += 1
+                continue
+            denied += 1
+            if event.reason == AuthorizationReason.NO_MATCHING_POLICY:
+                deny_no_matching_policy += 1
+            elif event.reason == AuthorizationReason.EXPLICIT_DENY:
+                deny_explicit_deny += 1
+            elif event.reason == AuthorizationReason.MISSING_REQUIRED_VERIFICATION:
+                deny_missing_required_verification += 1
+            elif event.reason == AuthorizationReason.MAX_DELEGATION_DEPTH_EXCEEDED:
+                deny_max_delegation_depth += 1
+            elif event.reason == AuthorizationReason.INVALID_MANDATE:
+                deny_invalid_mandate += 1
+            elif event.reason == AuthorizationReason.RATE_LIMIT_EXCEEDED:
+                deny_rate_limit_exceeded += 1
+        return DecisionStats(
+            total=len(events),
+            allowed=allowed,
+            denied=denied,
+            deny_no_matching_policy=deny_no_matching_policy,
+            deny_explicit_deny=deny_explicit_deny,
+            deny_missing_required_verification=deny_missing_required_verification,
+            deny_max_delegation_depth=deny_max_delegation_depth,
+            deny_invalid_mandate=deny_invalid_mandate,
+            deny_rate_limit_exceeded=deny_rate_limit_exceeded,
+        )

--- a/predicate_authority/rate_limit.py
+++ b/predicate_authority/rate_limit.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from threading import Lock
+
+
+@dataclass(frozen=True)
+class TokenBucketDecision:
+    allowed: bool
+    retry_after_s: float
+
+
+@dataclass
+class _TokenBucketState:
+    tokens: float
+    last_refill_s: float
+
+
+@dataclass(frozen=True)
+class PrincipalRateLimiterConfig:
+    enabled: bool = True
+    requests_per_second: float = 100.0
+    burst_size: int = 100
+
+
+@dataclass
+class PrincipalRateLimiter:
+    config: PrincipalRateLimiterConfig
+    clock: Callable[[], float] = time.monotonic
+    _lock: Lock = field(default_factory=Lock, init=False)
+    _buckets: dict[str, _TokenBucketState] = field(default_factory=dict, init=False)
+
+    def allow(self, principal_id: str) -> TokenBucketDecision:
+        if not self.config.enabled:
+            return TokenBucketDecision(allowed=True, retry_after_s=0.0)
+
+        now = self.clock()
+        with self._lock:
+            state = self._buckets.get(principal_id)
+            if state is None:
+                state = _TokenBucketState(
+                    tokens=float(max(1, self.config.burst_size) - 1),
+                    last_refill_s=now,
+                )
+                self._buckets[principal_id] = state
+                return TokenBucketDecision(allowed=True, retry_after_s=0.0)
+
+            self._refill(state, now)
+            if state.tokens >= 1.0:
+                state.tokens -= 1.0
+                return TokenBucketDecision(allowed=True, retry_after_s=0.0)
+
+            retry_after = self._retry_after_s(state.tokens)
+            return TokenBucketDecision(allowed=False, retry_after_s=retry_after)
+
+    def _refill(self, state: _TokenBucketState, now: float) -> None:
+        refill_rate = max(0.0, self.config.requests_per_second)
+        if refill_rate <= 0.0:
+            state.last_refill_s = now
+            return
+        elapsed = max(0.0, now - state.last_refill_s)
+        if elapsed <= 0.0:
+            return
+        state.tokens = min(
+            float(max(1, self.config.burst_size)),
+            state.tokens + (elapsed * refill_rate),
+        )
+        state.last_refill_s = now
+
+    def _retry_after_s(self, current_tokens: float) -> float:
+        refill_rate = max(0.0, self.config.requests_per_second)
+        if refill_rate <= 0.0:
+            return 1.0
+        missing_tokens = max(0.0, 1.0 - current_tokens)
+        return missing_tokens / refill_rate

--- a/predicate_contracts/models.py
+++ b/predicate_contracts/models.py
@@ -22,6 +22,7 @@ class AuthorizationReason(str, Enum):
     MISSING_REQUIRED_VERIFICATION = "missing_required_verification"
     MAX_DELEGATION_DEPTH_EXCEEDED = "max_delegation_depth_exceeded"
     INVALID_MANDATE = "invalid_mandate"
+    RATE_LIMIT_EXCEEDED = "rate_limit_exceeded"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
- 2026-02-19: Implemented Phase 3 rate limiting baseline in code: per-principal token-bucket limiting in `predicate-authority` sidecar (`AuthorizationReason.RATE_LIMIT_EXCEEDED`) and per-tenant API rate limiting in `predicate-authority-control-plane` with `429` + `Retry-After`; added deterministic tests for both paths.
- 2026-02-19: Implemented Phase 3 Prometheus metrics baseline in code for `predicate-authority` + `predicate-authority-control-plane` (`/metrics` endpoints, request latency/error counters, per-tenant rate-limit hit counter, policy propagation lag gauge, authorization decision/deny-reason counters, and daemon policy-reload/flush/control-plane-push counters) with deterministic tests.
- 2026-02-19: Implemented Phase 3 long-poll sync baseline for policy/revocation distribution: control-plane `GET /v1/sync/authority-updates` (sync token + bounded wait) and `predicate-authorityd` consumer loop (policy replace + revocation apply + sync counters/metrics) with deterministic integration tests.
- 2026-02-19: Implemented Phase 3 Merkle audit integrity baseline in control-plane: tenant-scoped root endpoint (`GET /v1/audit/integrity/root`) and event proof endpoint (`GET /v1/audit/integrity/proof/{event_id}`) with deterministic SHA-256 tree/proof generation and verification tests.
- 2026-02-19: Implemented Phase 3 control-plane circuit breaker baseline for store/database operations (closed/open/half-open with recovery timeout and fail-fast `503` while open), with deterministic breaker open/recovery tests.
- 2026-02-19: Implemented Phase 3 Kafka event streaming baseline in control-plane (pluggable event streamer + optional Kafka producer, topic emissions for policy/revocation/audit/usage writes, and fail-open/fail-closed behavior), with deterministic tests using a recording/failing streamer.